### PR TITLE
Adding in dependency -minify

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 mkdocs
 mkdocs-material
+mkdocs-minify-plugin
 pygments
 pymdown-extensions


### PR DESCRIPTION
mkdocs is looking for minify and it currently isn't installed causing my builds to fail (unless I am fundamentally doing something wrong?) 
Added to requirements for installer