### PR TITLE
Use alpine with dependencies that rely on node-gyp

### DIFF
--- a/docs/tutorial/our-application/index.md
+++ b/docs/tutorial/our-application/index.md
@@ -39,6 +39,7 @@ see a few flaws in the Dockerfile below. But, don't worry! We'll go over them.
 
     ```dockerfile
     FROM node:12-alpine
+    RUN apk add --no-cache --virtual .gyp python make g++ 
     WORKDIR /app
     COPY . .
     RUN yarn install --production


### PR DESCRIPTION
Node-gyp throws an error for missing Python dependency

Details as provided on the issue here [here](https://github.com/nodejs/docker-node/issues/282)