### PR TITLE
correct intent in 'Layer Caching' description

### DIFF
--- a/docs/tutorial/image-building-best-practices/index.md
+++ b/docs/tutorial/image-building-best-practices/index.md
@@ -44,7 +44,7 @@ command, you can see the command that was used to create each layer within an im
 
 ## Layer Caching
 
-Now that you've seen the layering in action, there's an important lesson to learn to help increase build
+Now that you've seen the layering in action, there's an important lesson to learn to help decrease build
 times for your container images.
 
 > Once a layer changes, all downstream layers have to be recreated as well


### PR DESCRIPTION
The description in the `Layer Caching` section of the `Image Building Best Practices` page of the tutorial mentioned the following:

> Now that you've seen the layering in action, there's an important lesson to learn to help **increase** build times for your container images.

but the suggestions mentioned in the section were to reduce the build time of the container images. Seems like the intent was wrongly mentioned in the above description. This is what was corrected to the following in this PR

> Now that you've seen the layering in action, there's an important lesson to learn to help **decrease** build times for your container images.
