### PR TITLE
update sha256 values to pass SRI checks

### DIFF
--- a/app/src/static/index.html
+++ b/app/src/static/index.html
@@ -12,10 +12,10 @@
 </head>
 <body>
     <div id="root"></div>
-    <script src="js/react.production.min.js" integrity="sha256-3vo65ZXn5pfsCfGM5H55X+SmwJHBlyNHPwRmWAPgJnM=" crossorigin="anonymous"></script>
-    <script src="js/react-dom.production.min.js" integrity="sha256-qVsF1ftL3vUq8RFOLwPnKimXOLo72xguDliIxeffHRc=" crossorigin="anonymous"></script>
-    <script src="js/react-bootstrap.js" integrity="sha256-6ovUv/6vh4PbrUjYfYLH5FRoBiMfWhR/manIR92XEws=" crossorigin="anonymous"></script>
-    <script src="js/babel.min.js" integrity="sha256-FiZMk1zgTeujzf/+vomWZGZ9r00+xnGvOgXoj0Jo1jA=" crossorigin="anonymous"></script>
+    <script src="js/react.production.min.js" integrity="sha256-9+vSqarg29SkRZPgHqGhak6fAnATU3fEPkN1Yw+i25s=" crossorigin="anonymous"></script>
+    <script src="js/react-dom.production.min.js" integrity="sha256-sp8nn9AyhHakaxibzqQsIsuF/fNQ6UDhwJOMAERMsxs=" crossorigin="anonymous"></script>
+    <script src="js/react-bootstrap.js" integrity="sha256-BYDF/Xl311qx4ajriU87g3bKXNm6Q7wfjmfDjZvOPLs=" crossorigin="anonymous"></script>
+    <script src="js/babel.min.js" integrity="sha256-0wja2UfK4fkY4sWYgLIp9NtcZLKen7TjG98MwaHFREw=" crossorigin="anonymous"></script>
     <script type="text/babel" src="js/app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
Based on this issue: https://github.com/docker/getting-started/issues/9 the base 64 encoded sha256 checksums as they exist break the container and result in a non working app.

These new values result in a working app on Docker Desktop CE Edge 2.2.3.0 running on Windows 10 Pro 2004.