### PR TITLE
Fix: 'COPY . .' should be changed to 'COPY ./app .' for the yarn install to work with a first sample Dockerfile

### DIFF
--- a/docs/tutorial/our-application/index.md
+++ b/docs/tutorial/our-application/index.md
@@ -40,7 +40,7 @@ see a few flaws in the Dockerfile below. But, don't worry! We'll go over them.
     ```dockerfile
     FROM node:12-alpine
     WORKDIR /app
-    COPY . .
+    COPY ./app .
     RUN yarn install --production
     CMD ["node", "/app/src/index.js"]
     ```


### PR DESCRIPTION
Followed the tutorial but section "Our Application" contains invalid Dockerfile which does not work :(