### PR TITLE
Fix: Update bind-mount image

### DIFF
--- a/docs/tutorial/using-bind-mounts/index.md
+++ b/docs/tutorial/using-bind-mounts/index.md
@@ -47,7 +47,7 @@ So, let's do it!
 
     - `-dp 3000:3000` - same as before. Run in detached (background) mode and create a port mapping
     - `-w /app` - sets the "working directory" or the current directory that the command will run from
-    - `node:12-alpine` - the image to use. Note that this is the base image for our app from the Dockerfile
+    - `getting-started` - the image to use. Note that this is the base image for our app from the Dockerfile
     - `sh -c "yarn install && yarn run dev"` - the command. We're starting a shell using `sh` (alpine doesn't have `bash`) and
       running `yarn install` to install _all_ dependencies and then running `yarn run dev`. If we look in the `package.json`,
       we'll see that the `dev` script is starting `nodemon`.

--- a/docs/tutorial/using-bind-mounts/index.md
+++ b/docs/tutorial/using-bind-mounts/index.md
@@ -41,7 +41,7 @@ So, let's do it!
     ```bash
     docker run -dp 3000:3000 \
         -w /app -v ${PWD}:/app \
-        node:12-alpine \
+        getting-started \
         sh -c "yarn install && yarn run dev"
     ```
 


### PR DESCRIPTION
This command will fail, as there is no existing app directory in the alpine image. We must provide the app image `getting-started` or the image from your Docker hub.