### PR TITLE
Explain `-v` option, explain how to write long PowerShell commands

### DIFF
--- a/docs/tutorial/multi-container-apps/index.md
+++ b/docs/tutorial/multi-container-apps/index.md
@@ -38,7 +38,7 @@ For now, we will create the network first and attach the MySQL container at star
     ```
 
 1. Start a MySQL container and attach it the network. We're also going to define a few environment variables that the
-  database will use to initialize the database (see the "Environment Variables" section in the [MySQL Docker Hub listing](https://hub.docker.com/_/mysql/)).
+  database will use to initialize the database (see the "Environment Variables" section in the [MySQL Docker Hub listing](https://hub.docker.com/_/mysql/)) (replace the ` \ ` characters with `` ` `` in Windows PowerShell).
 
     ```bash
     docker run -d \
@@ -165,7 +165,7 @@ The todo app supports the setting of a few environment variables to specify MySQ
 
 With all of that explained, let's start our dev-ready container!
 
-1. We'll specify each of the environment variables above, as well as connect the container to our app network.
+1. We'll specify each of the environment variables above, as well as connect the container to our app network (replace the ` \ ` characters with `` ` `` in Windows PowerShell).
 
     ```bash hl_lines="3 4 5 6 7"
     docker run -dp 3000:3000 \

--- a/docs/tutorial/using-bind-mounts/index.md
+++ b/docs/tutorial/using-bind-mounts/index.md
@@ -36,7 +36,7 @@ So, let's do it!
 
 1. Make sure you don't have any previous `getting-started` containers running.
 
-1. Run the following command. We'll explain what's going on afterwards:
+1. Run the following command (replace the ` \ ` characters with `` ` `` in Windows PowerShell). We'll explain what's going on afterwards:
 
     ```bash
     docker run -dp 3000:3000 \

--- a/docs/tutorial/using-bind-mounts/index.md
+++ b/docs/tutorial/using-bind-mounts/index.md
@@ -47,6 +47,7 @@ So, let's do it!
 
     - `-dp 3000:3000` - same as before. Run in detached (background) mode and create a port mapping
     - `-w /app` - sets the "working directory" or the current directory that the command will run from
+    - `-v ${PWD}:/app` - bind mound the current directory from the host in the container into the `/app` directory
     - `node:12-alpine` - the image to use. Note that this is the base image for our app from the Dockerfile
     - `sh -c "yarn install && yarn run dev"` - the command. We're starting a shell using `sh` (alpine doesn't have `bash`) and
       running `yarn install` to install _all_ dependencies and then running `yarn run dev`. If we look in the `package.json`,

--- a/docs/tutorial/using-docker-compose/index.md
+++ b/docs/tutorial/using-docker-compose/index.md
@@ -49,7 +49,7 @@ And now, we'll start migrating a service at a time into the compose file.
 
 ## Defining the App Service
 
-To remember, this was the command we were using to define our app container.
+To remember, this was the command we were using to define our app container (replace the ` \ ` characters with `` ` `` in Windows PowerShell).
 
 ```bash
 docker run -dp 3000:3000 \
@@ -145,7 +145,7 @@ docker run -dp 3000:3000 \
   
 ### Defining the MySQL Service
 
-Now, it's time to define the MySQL service. The command that we used for that container was the following:
+Now, it's time to define the MySQL service. The command that we used for that container was the following (replace the ` \ ` characters with `` ` `` in Windows PowerShell):
 
 ```bash
 docker run -d \


### PR DESCRIPTION
Explain the `-v` option in "Using Bind mounts" chapter.

Fixes #30 

This PR also adds an explanation to change backslashes `\` to backticks `` ` `` for Windows PowerShell users.
@mikesir87 WDYT? (I finally learn how to write a backtick in code blocks 😆)
