### PR TITLE
Avoid sending duplicate PUT requests when toggling completion

### DIFF
--- a/app/src/static/js/app.js
+++ b/app/src/static/js/app.js
@@ -117,7 +117,8 @@ function AddItemForm({ onNewItem }) {
 function ItemDisplay({ item, onItemUpdate, onItemRemoval }) {
     const { Container, Row, Col, Button } = ReactBootstrap;
 
-    const toggleCompletion = () => {
+    const toggleCompletion = (event) => {
+        event.stopPropagation()
         fetch(`/items/${item.id}`, {
             method: 'PUT',
             body: JSON.stringify({

--- a/app/src/static/js/app.js
+++ b/app/src/static/js/app.js
@@ -117,8 +117,7 @@ function AddItemForm({ onNewItem }) {
 function ItemDisplay({ item, onItemUpdate, onItemRemoval }) {
     const { Container, Row, Col, Button } = ReactBootstrap;
 
-    const toggleCompletion = (event) => {
-        event.stopPropagation()
+    const toggleCompletion = () => {
         fetch(`/items/${item.id}`, {
             method: 'PUT',
             body: JSON.stringify({
@@ -153,7 +152,6 @@ function ItemDisplay({ item, onItemUpdate, onItemRemoval }) {
                         }
                     >
                         <i
-                            onClick={toggleCompletion}
                             className={`far ${
                                 item.completed ? 'fa-check-square' : 'fa-square'
                             }`}


### PR DESCRIPTION
If the user clicks on the `<i>` element, the `onClick` event is propagated to the `<button>` which results in duplicate PUT request to the server.