### PR TITLE
Fix typo in -v description

### DIFF
--- a/docs/tutorial/using-bind-mounts/index.md
+++ b/docs/tutorial/using-bind-mounts/index.md
@@ -47,7 +47,7 @@ So, let's do it!
 
     - `-dp 3000:3000` - same as before. Run in detached (background) mode and create a port mapping
     - `-w /app` - sets the "working directory" or the current directory that the command will run from
-    - `-v ${PWD}:/app` - bind mound the current directory from the host in the container into the `/app` directory
+    - `-v ${PWD}:/app` - bind mount the current directory from the host in the container into the `/app` directory
     - `node:12-alpine` - the image to use. Note that this is the base image for our app from the Dockerfile
     - `sh -c "yarn install && yarn run dev"` - the command. We're starting a shell using `sh` (alpine doesn't have `bash`) and
       running `yarn install` to install _all_ dependencies and then running `yarn run dev`. If we look in the `package.json`,


### PR DESCRIPTION
The recently added description for the -v flag contained a typo in the word mount.