### PR TITLE
Removes timeout on mysql connection

### DIFF
--- a/app/src/persistence/mysql.js
+++ b/app/src/persistence/mysql.js
@@ -21,7 +21,7 @@ async function init() {
     const password = PASSWORD_FILE ? fs.readFileSync(PASSWORD_FILE) : PASSWORD;
     const database = DB_FILE ? fs.readFileSync(DB_FILE) : DB;
 
-    await waitPort({ host, port : 3306, timeout: 15000 });
+    await waitPort({ host, port : 3306});
 
     pool = mysql.createPool({
         connectionLimit: 5,


### PR DESCRIPTION
proposition to close #48

By removing the timeout, the todo application wait for the mysql container to be fully initialized and then create the connection.

It fixes the issue for me. Let me know if it would be a good solution. Or an other approach, such as implementing a fallback on the timeout to prevent the application from failing would be a better solution.