### PR TITLE
Match output to input and clarify build command

### DIFF
--- a/docs/tutorial/image-building-best-practices/index.md
+++ b/docs/tutorial/image-building-best-practices/index.md
@@ -94,7 +94,7 @@ a change to the `package.json`. Make sense?
     Step 2/6 : WORKDIR /app
     ---> Using cache
     ---> 9577ae713121
-    Step 3/6 : COPY package* yarn.lock ./
+    Step 3/6 : COPY package.json yarn.lock ./
     ---> bd5306f49fc8
     Step 4/6 : RUN yarn install --production
     ---> Running in d53a06c9e4c2
@@ -122,7 +122,7 @@ a change to the `package.json`. Make sense?
 
 1. Now, make a change to the `src/static/index.html` file (like change the `<title>` to say "The Awesome Todo App").
 
-1. Build the Docker image now using `docker build` again. This time, your output should look a little different.
+1. Build the Docker image now using `docker build -t getting-started .` again. This time, your output should look a little different.
 
     ```plaintext hl_lines="5 8 11"
     Sending build context to Docker daemon  219.1kB
@@ -131,7 +131,7 @@ a change to the `package.json`. Make sense?
     Step 2/6 : WORKDIR /app
     ---> Using cache
     ---> 9577ae713121
-    Step 3/6 : COPY package* yarn.lock ./
+    Step 3/6 : COPY package.json yarn.lock ./
     ---> Using cache
     ---> bd5306f49fc8
     Step 4/6 : RUN yarn install --production


### PR DESCRIPTION
The Dockerfile listed above specifically uses package.json, but the
output listed for the build lists package*, which is inconsistent. The
React example later in the doc uses package*, which would be consistent
with the output, but this should fix the mismatch for the beginner going
through the tutorial for the first time.

Additionally, the sentence "Build the Docker image now using 'docker
build' again" might be confusing to a beginner. I specifically tested
running this exact command and it gives an error message. Specifically
using the exact command needed to build this target shouldn't take up
too much space.