### PR TITLE
changed typo in command for connecting and checking mysql database

### DIFF
--- a/docs/tutorial/multi-container-apps/index.md
+++ b/docs/tutorial/multi-container-apps/index.md
@@ -199,7 +199,7 @@ With all of that explained, let's start our dev-ready container!
    is **secret**.
 
     ```bash
-    docker exec -ti <mysql-container-id> mysql -p todos
+    docker exec -it <mysql-container-id> mysql -p todos
     ```
 
     And in the mysql shell, run the following:


### PR DESCRIPTION
changed typo 
docker exec -ti <mysql-container-id> mysql -p todos
to
docker exec -it <mysql-container-id> mysql -p todos