### PR TITLE
Use single shorthand flags, better for beginners

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,10 @@ into depth, it covers the following topics:
 If you wish to run the tutorial, you can use the following command after installing Docker Desktop:
 
 ```bash
-docker run -dp 80:80 docker/getting-started
+docker run -d -p 80:80 docker/getting-started
 ```
 
 Once it has started, you can open your browser to [http://localhost](http://localhost).
-
 
 ## Development
 
@@ -34,13 +33,10 @@ local machine and help you see changes instantly.
 docker-compose up
 ```
 
-
 ## Contributing
 
 If you find typos or other issues with the tutorial, feel free to create a PR and suggest fixes!
 
-If you have ideas on how to make the tutorial better or new content, please open an issue first 
-before working on your idea. While we love input, we want to keep the tutorial is scoped to new-comers.
+If you have ideas on how to make the tutorial better or new content, please open an issue first before working on your idea. While we love input, we want to keep the tutorial is scoped to new-comers.
 As such, we may reject ideas for more advanced requests and don't want you to lose any work you might
 have done. So, ask first and we'll gladly hear your thoughts!
-


### PR DESCRIPTION
The README suggests to run the docker/getting-started container with combined `-dp 80:80` parameters.
The tutorial itself shows seperate flags `-d` and `-p 80:80` and explains it.  We should adjust the README and use the beginners friendly command.

Also did some markdown cleanup in VSCode.