### PR TITLE
Show multiline PowerShell commands

### DIFF
--- a/docs/tutorial/multi-container-apps/index.md
+++ b/docs/tutorial/multi-container-apps/index.md
@@ -180,7 +180,7 @@ With all of that explained, let's start our dev-ready container!
 
     ```bash hl_lines="3 4 5 6 7"
     docker run -dp 3000:3000 \
-      -w /app -v ${PWD}:/app \
+      -w /app -v "$(pwd):/app" \
       --network todo-app \
       -e MYSQL_HOST=mysql \
       -e MYSQL_USER=root \
@@ -194,7 +194,7 @@ With all of that explained, let's start our dev-ready container!
 
     ```powershell hl_lines="3 4 5 6 7"
     docker run -dp 3000:3000 `
-      -w /app -v ${PWD}:/app `
+      -w /app -v "$(pwd):/app" `
       --network todo-app `
       -e MYSQL_HOST=mysql `
       -e MYSQL_USER=root `

--- a/docs/tutorial/multi-container-apps/index.md
+++ b/docs/tutorial/multi-container-apps/index.md
@@ -38,7 +38,7 @@ For now, we will create the network first and attach the MySQL container at star
     ```
 
 1. Start a MySQL container and attach it the network. We're also going to define a few environment variables that the
-  database will use to initialize the database (see the "Environment Variables" section in the [MySQL Docker Hub listing](https://hub.docker.com/_/mysql/)) (replace the ` \ ` characters with `` ` `` in Windows PowerShell).
+  database will use to initialize the database (see the "Environment Variables" section in the [MySQL Docker Hub listing](https://hub.docker.com/_/mysql/)).
 
     ```bash
     docker run -d \
@@ -46,6 +46,17 @@ For now, we will create the network first and attach the MySQL container at star
         -v todo-mysql-data:/var/lib/mysql \
         -e MYSQL_ROOT_PASSWORD=secret \
         -e MYSQL_DATABASE=todos \
+        mysql:5.7
+    ```
+
+    If you are using PowerShell then use this command.
+
+    ```powershell
+    docker run -d `
+        --network todo-app --network-alias mysql `
+        -v todo-mysql-data:/var/lib/mysql `
+        -e MYSQL_ROOT_PASSWORD=secret `
+        -e MYSQL_DATABASE=todos `
         mysql:5.7
     ```
 
@@ -165,7 +176,7 @@ The todo app supports the setting of a few environment variables to specify MySQ
 
 With all of that explained, let's start our dev-ready container!
 
-1. We'll specify each of the environment variables above, as well as connect the container to our app network (replace the ` \ ` characters with `` ` `` in Windows PowerShell).
+1. We'll specify each of the environment variables above, as well as connect the container to our app network.
 
     ```bash hl_lines="3 4 5 6 7"
     docker run -dp 3000:3000 \
@@ -176,6 +187,20 @@ With all of that explained, let's start our dev-ready container!
       -e MYSQL_PASSWORD=secret \
       -e MYSQL_DB=todos \
       node:12-alpine \
+      sh -c "yarn install && yarn run dev"
+    ```
+
+    If you are using PowerShell then use this command.
+
+    ```powershell hl_lines="3 4 5 6 7"
+    docker run -dp 3000:3000 `
+      -w /app -v ${PWD}:/app `
+      --network todo-app `
+      -e MYSQL_HOST=mysql `
+      -e MYSQL_USER=root `
+      -e MYSQL_PASSWORD=secret `
+      -e MYSQL_DB=todos `
+      node:12-alpine `
       sh -c "yarn install && yarn run dev"
     ```
 

--- a/docs/tutorial/using-bind-mounts/index.md
+++ b/docs/tutorial/using-bind-mounts/index.md
@@ -40,7 +40,7 @@ So, let's do it!
 
     ```bash
     docker run -dp 3000:3000 \
-        -w /app -v ${PWD}:/app \
+        -w /app -v "$(pwd):/app" \
         node:12-alpine \
         sh -c "yarn install && yarn run dev"
     ```
@@ -49,14 +49,14 @@ So, let's do it!
 
     ```powershell
     docker run -dp 3000:3000 `
-        -w /app -v ${PWD}:/app `
+        -w /app -v "$(pwd):/app" `
         node:12-alpine `
         sh -c "yarn install && yarn run dev"
     ```
 
     - `-dp 3000:3000` - same as before. Run in detached (background) mode and create a port mapping
     - `-w /app` - sets the "working directory" or the current directory that the command will run from
-    - `-v ${PWD}:/app` - bind mount the current directory from the host in the container into the `/app` directory
+    - `-v "$(pwd):/app"` - bind mount the current directory from the host in the container into the `/app` directory
     - `node:12-alpine` - the image to use. Note that this is the base image for our app from the Dockerfile
     - `sh -c "yarn install && yarn run dev"` - the command. We're starting a shell using `sh` (alpine doesn't have `bash`) and
       running `yarn install` to install _all_ dependencies and then running `yarn run dev`. If we look in the `package.json`,

--- a/docs/tutorial/using-bind-mounts/index.md
+++ b/docs/tutorial/using-bind-mounts/index.md
@@ -36,12 +36,21 @@ So, let's do it!
 
 1. Make sure you don't have any previous `getting-started` containers running.
 
-1. Run the following command (replace the ` \ ` characters with `` ` `` in Windows PowerShell). We'll explain what's going on afterwards:
+1. Run the following command. We'll explain what's going on afterwards:
 
     ```bash
     docker run -dp 3000:3000 \
         -w /app -v ${PWD}:/app \
         node:12-alpine \
+        sh -c "yarn install && yarn run dev"
+    ```
+
+    If you are using PowerShell then use this command.
+
+    ```powershell
+    docker run -dp 3000:3000 `
+        -w /app -v ${PWD}:/app `
+        node:12-alpine `
         sh -c "yarn install && yarn run dev"
     ```
 

--- a/docs/tutorial/using-docker-compose/index.md
+++ b/docs/tutorial/using-docker-compose/index.md
@@ -49,7 +49,7 @@ And now, we'll start migrating a service at a time into the compose file.
 
 ## Defining the App Service
 
-To remember, this was the command we were using to define our app container (replace the ` \ ` characters with `` ` `` in Windows PowerShell).
+To remember, this was the command we were using to define our app container.
 
 ```bash
 docker run -dp 3000:3000 \
@@ -60,6 +60,20 @@ docker run -dp 3000:3000 \
   -e MYSQL_PASSWORD=secret \
   -e MYSQL_DB=todos \
   node:12-alpine \
+  sh -c "yarn install && yarn run dev"
+```
+
+If you are using PowerShell then use this command.
+
+```powershell
+docker run -dp 3000:3000 `
+  -w /app -v ${PWD}:/app `
+  --network todo-app `
+  -e MYSQL_HOST=mysql `
+  -e MYSQL_USER=root `
+  -e MYSQL_PASSWORD=secret `
+  -e MYSQL_DB=todos `
+  node:12-alpine `
   sh -c "yarn install && yarn run dev"
 ```
 
@@ -145,7 +159,7 @@ docker run -dp 3000:3000 \
   
 ### Defining the MySQL Service
 
-Now, it's time to define the MySQL service. The command that we used for that container was the following (replace the ` \ ` characters with `` ` `` in Windows PowerShell):
+Now, it's time to define the MySQL service. The command that we used for that container was the following:
 
 ```bash
 docker run -d \
@@ -153,6 +167,17 @@ docker run -d \
   -v todo-mysql-data:/var/lib/mysql \
   -e MYSQL_ROOT_PASSWORD=secret \
   -e MYSQL_DATABASE=todos \
+  mysql:5.7
+```
+
+If you are using PowerShell then use this command.
+
+```powershell
+docker run -d `
+  --network todo-app --network-alias mysql `
+  -v todo-mysql-data:/var/lib/mysql `
+  -e MYSQL_ROOT_PASSWORD=secret `
+  -e MYSQL_DATABASE=todos `
   mysql:5.7
 ```
 

--- a/docs/tutorial/using-docker-compose/index.md
+++ b/docs/tutorial/using-docker-compose/index.md
@@ -53,7 +53,7 @@ To remember, this was the command we were using to define our app container.
 
 ```bash
 docker run -dp 3000:3000 \
-  -w /app -v ${PWD}:/app \
+  -w /app -v "$(pwd):/app" \
   --network todo-app \
   -e MYSQL_HOST=mysql \
   -e MYSQL_USER=root \
@@ -67,7 +67,7 @@ If you are using PowerShell then use this command.
 
 ```powershell
 docker run -dp 3000:3000 `
-  -w /app -v ${PWD}:/app `
+  -w /app -v "$(pwd):/app" `
   --network todo-app `
   -e MYSQL_HOST=mysql `
   -e MYSQL_USER=root `
@@ -116,7 +116,7 @@ docker run -dp 3000:3000 `
           - 3000:3000
     ```
 
-1. Next, we'll migrate both the working directory (`-w /app`) and the volume mapping (`-v ${PWD}:/app`) by using
+1. Next, we'll migrate both the working directory (`-w /app`) and the volume mapping (`-v "$(pwd):/app"`) by using
    the `working_dir` and `volumes` definitions. Volumes also has a [short](https://docs.docker.com/compose/compose-file/#short-syntax-3) and [long](https://docs.docker.com/compose/compose-file/#long-syntax-3) syntax.
 
     One advantage of Docker Compose volume definitions is we can use relative paths from the current directory.


### PR DESCRIPTION
Show all multiline commands both for `bash` (Linux, Mac, WSL 2) and PowerShell. PowerShell uses a different line continuation character. We explained what to change, but it's easier for the users to have a copy-pastable command that works in PowerShell.

Fixes #64 

Also switch from `-v ${PWD}:/app` to `-v "$(pwd):/app"` to support more Linux distributions. The quotes are needed in PowerShell, and may be needed if a Linux user has the sample source code in a path that contains spaces.

Fixes #14
