### PR TITLE
Add "Unix/Windows" support for shell commands

### DIFF
--- a/docs/tutorial/multi-container-apps/index.md
+++ b/docs/tutorial/multi-container-apps/index.md
@@ -40,6 +40,8 @@ For now, we will create the network first and attach the MySQL container at star
 1. Start a MySQL container and attach it the network. We're also going to define a few environment variables that the
   database will use to initialize the database (see the "Environment Variables" section in the [MySQL Docker Hub listing](https://hub.docker.com/_/mysql/)).
 
+=== "Unix"
+
     ```bash
     docker run -d \
         --network todo-app --network-alias mysql \
@@ -48,9 +50,7 @@ For now, we will create the network first and attach the MySQL container at star
         -e MYSQL_DATABASE=todos \
         mysql:5.7
     ```
-
-    If you are using PowerShell then use this command.
-
+=== "Windows"
     ```powershell
     docker run -d `
         --network todo-app --network-alias mysql `
@@ -178,6 +178,8 @@ With all of that explained, let's start our dev-ready container!
 
 1. We'll specify each of the environment variables above, as well as connect the container to our app network.
 
+=== "Unix"
+
     ```bash hl_lines="3 4 5 6 7"
     docker run -dp 3000:3000 \
       -w /app -v "$(pwd):/app" \
@@ -189,9 +191,7 @@ With all of that explained, let's start our dev-ready container!
       node:12-alpine \
       sh -c "yarn install && yarn run dev"
     ```
-
-    If you are using PowerShell then use this command.
-
+=== "Windows"
     ```powershell hl_lines="3 4 5 6 7"
     docker run -dp 3000:3000 `
       -w /app -v "$(pwd):/app" `

--- a/docs/tutorial/using-bind-mounts/index.md
+++ b/docs/tutorial/using-bind-mounts/index.md
@@ -37,6 +37,7 @@ So, let's do it!
 1. Make sure you don't have any previous `getting-started` containers running.
 
 1. Run the following command. We'll explain what's going on afterwards:
+=== "Unix"
 
     ```bash
     docker run -dp 3000:3000 \
@@ -45,7 +46,7 @@ So, let's do it!
         sh -c "yarn install && yarn run dev"
     ```
 
-    If you are using PowerShell then use this command.
+=== "Windows"
 
     ```powershell
     docker run -dp 3000:3000 `

--- a/docs/tutorial/using-docker-compose/index.md
+++ b/docs/tutorial/using-docker-compose/index.md
@@ -51,31 +51,32 @@ And now, we'll start migrating a service at a time into the compose file.
 
 To remember, this was the command we were using to define our app container.
 
-```bash
-docker run -dp 3000:3000 \
-  -w /app -v "$(pwd):/app" \
-  --network todo-app \
-  -e MYSQL_HOST=mysql \
-  -e MYSQL_USER=root \
-  -e MYSQL_PASSWORD=secret \
-  -e MYSQL_DB=todos \
-  node:12-alpine \
-  sh -c "yarn install && yarn run dev"
-```
+=== "Unix"
+   ```bash
+   docker run -dp 3000:3000 \
+     -w /app -v "$(pwd):/app" \
+     --network todo-app \
+     -e MYSQL_HOST=mysql \
+     -e MYSQL_USER=root \
+     -e MYSQL_PASSWORD=secret \
+     -e MYSQL_DB=todos \
+     node:12-alpine \
+     sh -c "yarn install && yarn run dev"
+   ```
 
-If you are using PowerShell then use this command.
+=== "Windows"
 
-```powershell
-docker run -dp 3000:3000 `
-  -w /app -v "$(pwd):/app" `
-  --network todo-app `
-  -e MYSQL_HOST=mysql `
-  -e MYSQL_USER=root `
-  -e MYSQL_PASSWORD=secret `
-  -e MYSQL_DB=todos `
-  node:12-alpine `
-  sh -c "yarn install && yarn run dev"
-```
+   ```powershell
+   docker run -dp 3000:3000 `
+     -w /app -v "$(pwd):/app" `
+     --network todo-app `
+     -e MYSQL_HOST=mysql `
+     -e MYSQL_USER=root `
+     -e MYSQL_PASSWORD=secret `
+     -e MYSQL_DB=todos `
+     node:12-alpine `
+     sh -c "yarn install && yarn run dev"
+   ```
 
 1. First, let's define the service entry and the image for the container. We can pick any name for the service. 
    The name will automatically become a network alias, which will be useful when defining our MySQL service.
@@ -161,25 +162,27 @@ docker run -dp 3000:3000 `
 
 Now, it's time to define the MySQL service. The command that we used for that container was the following:
 
-```bash
-docker run -d \
-  --network todo-app --network-alias mysql \
-  -v todo-mysql-data:/var/lib/mysql \
-  -e MYSQL_ROOT_PASSWORD=secret \
-  -e MYSQL_DATABASE=todos \
-  mysql:5.7
-```
+=== "Unix"
 
-If you are using PowerShell then use this command.
+   ```bash
+   docker run -d \
+     --network todo-app --network-alias mysql \
+     -v todo-mysql-data:/var/lib/mysql \
+     -e MYSQL_ROOT_PASSWORD=secret \
+     -e MYSQL_DATABASE=todos \
+     mysql:5.7
+   ```
 
-```powershell
-docker run -d `
-  --network todo-app --network-alias mysql `
-  -v todo-mysql-data:/var/lib/mysql `
-  -e MYSQL_ROOT_PASSWORD=secret `
-  -e MYSQL_DATABASE=todos `
-  mysql:5.7
-```
+=== "Windows"
+
+   ```powershell
+   docker run -d `
+     --network todo-app --network-alias mysql `
+     -v todo-mysql-data:/var/lib/mysql `
+     -e MYSQL_ROOT_PASSWORD=secret `
+     -e MYSQL_DATABASE=todos `
+     mysql:5.7
+   ```
 
 1. We will first define the new service and name it `mysql` so it automatically gets the network alias. We'll
    go ahead and specify the image to use as well.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -65,6 +65,7 @@ markdown_extensions:
   - pymdownx.tasklist:
       custom_checkbox: true
   - pymdownx.tilde
+  - pymdownx.tabbed
   - attr_list
 
 # Page tree


### PR DESCRIPTION
As described in [mkdocs-material documentation](https://squidfunk.github.io/mkdocs-material/reference/content-tabs/#tabbed), "content tabs" can be added into the markdown.

This feature can be used to group coding blocks content.
In this project, `Bash commands` and `Powershell commands` syntax may differ, and this is why we can add `code block groups` in order to group the `Bash` and `Powershell` commands together. 