### PR TITLE
Update index.md

### DIFF
--- a/docs/tutorial/persisting-our-data/index.md
+++ b/docs/tutorial/persisting-our-data/index.md
@@ -147,7 +147,8 @@ need to have root access to access this directory from the host. But, that's whe
 !!! info "Accessing Volume data directly on Docker Desktop"
     While running in Docker Desktop, the Docker commands are actually running inside a small VM on your machine.
     If you wanted to look at the actual contents of the Mountpoint directory, you would need to first get inside
-    of the VM.
+    of the VM. In WSL2, Docker Desktop for Windows, the repository is located at:
+    \\wsl$\docker-desktop\mnt\host\wsl\docker-desktop-data\data\docker\volumes\todo-db\_data
 
 ## Recap
 


### PR DESCRIPTION
Section, "Diving into our Volume" subsection, "Accessing Volume data directly on Docker Desktop"
Save other Docker Desktop for Windows users the same hassle I had of verifying the non-existent volume repository: "Mountpoint": "/var/lib/docker/volumes/todo-db/_data",
In WSL2, Docker Desktop for Windows, the repository is located at: \\wsl$\docker-desktop\mnt\host\wsl\docker-desktop-data\data\docker\volumes\todo-db\_data
Ref: https://stackoverflow.com/a/63668192/14096774