### PR TITLE
Build amd64 and arm64 image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN pip install -r requirements.txt
 
 # Run tests to validate app
 FROM node:12-alpine AS app-base
+RUN apk add --no-cache python g++ make
 WORKDIR /app
 COPY app/package.json app/yarn.lock ./
 RUN yarn install

--- a/build.sh
+++ b/build.sh
@@ -9,6 +9,6 @@ else
 fi
 
 docker buildx build \
-      --platform linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6 \
+      --platform linux/amd64,linux/arm64 \
       -t docker/getting-started:latest \
       $( (( $WILL_PUSH == 1 )) && printf %s '--push' ) .


### PR DESCRIPTION
For non-amd64 platforms we need python, make and g++ to compile sqlite3 node module.
Removing arm 32bit from build.sh script as we don't need it on these platforms to save build time.

This change is required to have a smooth onboarding experience on Apple Silicon machines.
