### PR TITLE
Update index.md from using bind mount

### DIFF
--- a/docs/tutorial/using-bind-mounts/index.md
+++ b/docs/tutorial/using-bind-mounts/index.md
@@ -36,7 +36,7 @@ So, let's do it!
 
 1. Make sure you don't have any previous `getting-started` containers running.
 
-1. Run the following command. We'll explain what's going on afterwards:
+1. Run the following command from the source code folder. We'll explain what's going on afterwards:
 
     ```bash
     docker run -dp 3000:3000 \


### PR DESCRIPTION
The command for bind mount doesn't run in Ubuntu if the user is not in the source code folder. At least, for me didn't work. So I specified that to prevent errors and bugs.