### PR TITLE
Update index.md

### DIFF
--- a/docs/tutorial/using-bind-mounts/index.md
+++ b/docs/tutorial/using-bind-mounts/index.md
@@ -53,10 +53,14 @@ So, let's do it!
         node:12-alpine `
         sh -c "yarn install && yarn run dev"
     ```
+    
 
     - `-dp 3000:3000` - same as before. Run in detached (background) mode and create a port mapping
     - `-w /app` - sets the "working directory" or the current directory that the command will run from
     - `-v "$(pwd):/app"` - bind mount the current directory from the host in the container into the `/app` directory
+        
+        **NOTE:** when running from a Windows host you may need to use a different syntax.  For example if your project
+        is located in `c:\appdir\app` then type `-v "//c/appdir/app:/app"`
     - `node:12-alpine` - the image to use. Note that this is the base image for our app from the Dockerfile
     - `sh -c "yarn install && yarn run dev"` - the command. We're starting a shell using `sh` (alpine doesn't have `bash`) and
       running `yarn install` to install _all_ dependencies and then running `yarn run dev`. If we look in the `package.json`,


### PR DESCRIPTION
This is an update to advise the -v command in Windows hosts should be represented as "//drive/app_path"  as ($pwd) does not work.