### PR TITLE
Add build tools to fix arm64 build issue

### DIFF
--- a/docs/tutorial/our-application/index.md
+++ b/docs/tutorial/our-application/index.md
@@ -38,6 +38,7 @@ see a few flaws in the Dockerfile below. But, don't worry! We'll go over them.
 
     ```dockerfile
     FROM node:12-alpine
+    RUN apk add --no-cache python g++ make
     WORKDIR /app
     COPY . .
     RUN yarn install --production


### PR DESCRIPTION
Fix the `Dockerfile` in the tutorial just like we did in #104 to make the `docker build -t getting-started .` command work on Apple Silicon or other arm64 machines.
