### PR TITLE
Update dev mode command to install sqlite3 deps

### DIFF
--- a/docs/tutorial/using-bind-mounts/index.md
+++ b/docs/tutorial/using-bind-mounts/index.md
@@ -60,7 +60,7 @@ So, let's do it!
     docker run -dp 3000:3000 \
         -w /app -v "$(pwd):/app" \
         node:12-alpine \
-        sh -c "apk add --no-cache python g++ make && yarn install && yarn run dev"
+        sh -c "apk add --no-cache python2 g++ make && yarn install && yarn run dev"
     ```
 
     - `-dp 3000:3000` - same as before. Run in detached (background) mode and create a port mapping

--- a/docs/tutorial/using-bind-mounts/index.md
+++ b/docs/tutorial/using-bind-mounts/index.md
@@ -54,6 +54,15 @@ So, let's do it!
         sh -c "yarn install && yarn run dev"
     ```
 
+    If you are using an Apple Silicon Mac or another ARM64 device then use this command.
+
+    ```bash
+    docker run -dp 3000:3000 \
+        -w /app -v "$(pwd):/app" \
+        node:12-alpine \
+        sh -c "apk add --no-cache python g++ make && yarn install && yarn run dev"
+    ```
+
     - `-dp 3000:3000` - same as before. Run in detached (background) mode and create a port mapping
     - `-w /app` - sets the "working directory" or the current directory that the command will run from
     - `-v "$(pwd):/app"` - bind mount the current directory from the host in the container into the `/app` directory


### PR DESCRIPTION
With many thanks to [@samjewell](https://github.com/docker/getting-started/issues/124#issuecomment-782028688).

Also, at this point in the tutorial, it's not clear that this command isn't using the `Dockerfile` added in the 2nd step.  I'm not sure how to communicate that, so I've left it out.  I found [this comment](https://github.com/docker/getting-started/issues/36#issuecomment-753847145) and could see that my `Dockerfile` already had the sqlite3 deps, so was pulling my hair out resetting & uninstalling Docker trying to get it to work. :/

Hopefully closes #124 