### PR TITLE
fix: path to db file in test

### DIFF
--- a/app/spec/persistence/sqlite.spec.js
+++ b/app/spec/persistence/sqlite.spec.js
@@ -1,5 +1,6 @@
 const db = require('../../src/persistence/sqlite');
 const fs = require('fs');
+const location = process.env.SQLITE_DB_LOCATION || '/etc/todos/todo.db';
 
 const ITEM = {
     id: '7aef3d7c-d301-4846-8358-2a91ec9d6be3',
@@ -8,8 +9,8 @@ const ITEM = {
 };
 
 beforeEach(() => {
-    if (fs.existsSync('/etc/todos/todo.db')) {
-        fs.unlinkSync('/etc/todos/todo.db');
+    if (fs.existsSync(location)) {
+        fs.unlinkSync(location);
     }
 });
 


### PR DESCRIPTION
- Path `/etc/todos/todo.db` is hardcoded [here](https://github.com/docker/getting-started/blob/13386236e44b3b599e68faf3ee187894b42969b7/app/spec/persistence/sqlite.spec.js#L11). This fails tests if I don't have edit access to `/etc` on my system
- changed it to take this path from the env variable `SQLITE_DB_LOCATION` and take `'/etc/todos/todo.db'` as a fallback just like [here](https://github.com/docker/getting-started/blob/13386236e44b3b599e68faf3ee187894b42969b7/app/src/persistence/sqlite.js#L3)