### PR TITLE
fixed base image reference

### DIFF
--- a/docs/tutorial/using-bind-mounts/index.md
+++ b/docs/tutorial/using-bind-mounts/index.md
@@ -41,7 +41,7 @@ So, let's do it!
     ```bash
     docker run -dp 3000:3000 \
         -w /app -v "$(pwd):/app" \
-        node:12-alpine \
+        getting-started \
         sh -c "yarn install && yarn run dev"
     ```
 
@@ -50,15 +50,15 @@ So, let's do it!
     ```powershell
     docker run -dp 3000:3000 `
         -w /app -v "$(pwd):/app" `
-        node:12-alpine `
+        getting-started `
         sh -c "yarn install && yarn run dev"
     ```
 
     - `-dp 3000:3000` - same as before. Run in detached (background) mode and create a port mapping
     - `-w /app` - sets the "working directory" or the current directory that the command will run from
     - `-v "$(pwd):/app"` - bind mount the current directory from the host in the container into the `/app` directory
-    - `node:12-alpine` - the image to use. Note that this is the base image for our app from the Dockerfile
-    - `sh -c "yarn install && yarn run dev"` - the command. We're starting a shell using `sh` (alpine doesn't have `bash`) and
+    - `getting-started` - the image to use. Note that this is the base image for our app from the Dockerfile
+    - `sh -c "yarn install && yarn run dev"` - the command. We're starting a shell using `sh` (getting-started doesn't have `bash`) and
       running `yarn install` to install _all_ dependencies and then running `yarn run dev`. If we look in the `package.json`,
       we'll see that the `dev` script is starting `nodemon`.
 


### PR DESCRIPTION
I was reading the Getting Started tutorial and noticed that the base image in the section Using Bind Mounts didn't work.

```bash
docker run -dp 3000:3000 \
    -w /app -v "$(pwd):/app" \
    node:12-alpine \
    sh -c "yarn install && yarn run dev"
```

the image node:12-alpine is throwing an error because some dependencies require python to install them, at this stage python was installed in the getting-started image from the Dockerfile. 

The correct base image should be getting-started.

```bash
docker run -dp 3000:3000 \
    -w /app -v "$(pwd):/app" \
    getting-started \
    sh -c "yarn install && yarn run dev"
```