### PR TITLE
Removed body-parser as a dependency.

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -9,7 +9,6 @@
     "dev": "nodemon src/index.js"
   },
   "dependencies": {
-    "body-parser": "^1.19.0",
     "express": "^4.17.1",
     "mysql": "^2.17.1",
     "sqlite3": "^4.1.0",

--- a/app/src/index.js
+++ b/app/src/index.js
@@ -6,7 +6,7 @@ const addItem = require('./routes/addItem');
 const updateItem = require('./routes/updateItem');
 const deleteItem = require('./routes/deleteItem');
 
-app.use(require('body-parser').json());
+app.use(express.json());
 app.use(express.static(__dirname + '/static'));
 
 app.get('/items', getItems);


### PR DESCRIPTION
Express 4.16+ uses body-parser by default so it is not necessary to add body-parser as a dependency unless you absolutely require it. This PR removes the use of the package from the code.
[Refer to this article for more details.](https://medium.com/@mmajdanski/express-body-parser-and-why-may-not-need-it-335803cd048c)