### PR TITLE
Update using-bind-mounts tutorial for cmd.exe

### DIFF
--- a/docs/tutorial/using-bind-mounts/index.md
+++ b/docs/tutorial/using-bind-mounts/index.md
@@ -38,6 +38,15 @@ So, let's do it!
 
 1. Run the following command. We'll explain what's going on afterwards:
 
+    ```bat
+    docker run -dp 3000:3000 \
+        -w /app -v %cd%:/app \
+        node:12-alpine \
+        sh -c "yarn install && yarn run dev"
+    ```
+
+    If you are using bash:
+    
     ```bash
     docker run -dp 3000:3000 \
         -w /app -v "$(pwd):/app" \


### PR DESCRIPTION
As a user following these instructions directly from a Docker-on-windows installation, I expected the steps all to work using cmd.exe.
If they are *meant* to work on cmd.exe, then can we add this section (proposed)?
If the instructions are meant to be bash / PowerShell only then we can scrap the example (but labeling the first command as bash would still be nice).

The markdown clearly shows the language, but viewing the rendered instructions hides the information from view!