### PR TITLE
Increase mkdoc version to 1.2.2.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-mkdocs==1.0.4
+mkdocs==1.2.2
 mkdocs-material==4.6.3
 mkdocs-minify-plugin==0.2.3
 pygments==2.7.4


### PR DESCRIPTION
python:alpine is now points to python3.10, with old mkdoc, it will reports:

```
from collections import Sequence, namedtuple
ImportError: cannot import name 'Sequence' from 'collections' (/usr/local/lib/python3.10/collections/__init__.py)
```

This is due to:
> Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.10 it will stop working

Signed-off-by: atline <atline@aliyun.com>