### PR TITLE
fix python image version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Install the base requirements for the app.
 # This stage is to support development.
-FROM python:alpine AS base
+FROM python:3.8-alpine AS base
 WORKDIR /app
 COPY requirements.txt .
 RUN pip install -r requirements.txt


### PR DESCRIPTION
By default docker101tutorial uses python 3.10 alpine docker image. mkdocs build cannot succeed there
Lockign python version, fixes the build.