### PR TITLE
Removed 'RUN apk add --no-cache python g++ make'

### DIFF
--- a/docs/tutorial/our-application/index.md
+++ b/docs/tutorial/our-application/index.md
@@ -38,7 +38,6 @@ see a few flaws in the Dockerfile below. But, don't worry! We'll go over them.
 
     ```dockerfile
     FROM node:12-alpine
-    RUN apk add --no-cache python g++ make
     WORKDIR /app
     COPY . .
     RUN yarn install --production


### PR DESCRIPTION
This line did not appear to be necessary for the tutorial. Testing with it removed appeared to have no effect. Additionally, this line does not appear later in the tutorial when referring back to this step (see /docs/tutorial/image-building-best-practices/index.md).