### PR TITLE
Update index.md

### DIFF
--- a/docs/tutorial/our-application/index.md
+++ b/docs/tutorial/our-application/index.md
@@ -38,7 +38,7 @@ see a few flaws in the Dockerfile below. But, don't worry! We'll go over them.
 
     ```dockerfile
     FROM node:12-alpine
-    RUN apk add --no-cache python g++ make
+    RUN apk add --no-cache python3 g++ make
     WORKDIR /app
     COPY . .
     RUN yarn install --production


### PR DESCRIPTION
Without a specified python version running docker build results in an error, e.g `ERROR [2/5] RUN apk add --no-cache python g++ make`