### PR TITLE
Update RUN command with python

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN pip install -r requirements.txt
 
 # Run tests to validate app
 FROM node:12-alpine AS app-base
-RUN apk add --no-cache python g++ make
+RUN apk add --no-cache python2 g++ make
 WORKDIR /app
 COPY app/package.json app/yarn.lock ./
 RUN yarn install

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ docker run -d -p 80:80 docker/getting-started
 
 Once it has started, you can open your browser to [http://localhost](http://localhost).
 
+If you got `ERROR [app-base 2/8] RUN apk add --no-cache python g++ make` try to change the Dockerfile by editing `python` to `python2` or `pythonN` based on your python version.
+
 ## Development
 
 This project has a `docker-compose.yml` file, which will start the mkdocs application on your


### PR DESCRIPTION
Use python2 in the RUN command to avoid the common error for the very first tutorial.
Looks like just `python` doesn't work nowadays. 