### PR TITLE
Faster getting started guide, fix for Apple silicon

### DIFF
--- a/docs/tutorial/our-application/index.md
+++ b/docs/tutorial/our-application/index.md
@@ -38,6 +38,8 @@ see a few flaws in the Dockerfile below. But, don't worry! We'll go over them.
 
     ```dockerfile
     FROM node:12-alpine
+    # Adding build tools to make yarn install work on Apple silicon / arm64 machines
+    RUN apk add --no-cache python3 g++ make
     WORKDIR /app
     COPY . .
     RUN yarn install --production


### PR DESCRIPTION
The tutorial regularly fails for users because of the tons of dependencies that has to be pulled and installed during the test phase of the Dockerfile. Then it failed for Apple M1 users due to missing build tools to compile some native Node.js packages. All in all we put more dependencies into this and slowed down the whole experience of the "Getting Started Guide" in Docker Desktop.

I now looked closer and realised that the test step isn't required, so I just removed the additional dependencies and the whole test step. So the tutorial is much faster again and less likely to fail.

For the later tutorial when an user walks through all the steps, the Dockerfile shown to use actually has the build dependencies, so it will work for all users, both working with Intel/AMD machines as well as Apple silicon/M1/arm64 machines.

If we still want to test the application, for example in CI, then we can use the main Dockerfile with `docker build -t tutorial --target test .`, but the default target is just building the mkdocs page.

Fixes https://github.com/docker/for-mac/issues/6036
Fixes #217 
