### PR TITLE
fix on 'Our Application' tutorial for Apple silicon

### DIFF
--- a/docs/tutorial/our-application/index.md
+++ b/docs/tutorial/our-application/index.md
@@ -39,7 +39,7 @@ see a few flaws in the Dockerfile below. But, don't worry! We'll go over them.
     ```dockerfile
     FROM node:12-alpine
     # Adding build tools to make yarn install work on Apple silicon / arm64 machines
-    RUN apk add --no-cache python3 g++ make
+    RUN apk add --no-cache python2 g++ make
     WORKDIR /app
     COPY . .
     RUN yarn install --production


### PR DESCRIPTION
I could not successfully run `docker build -t getting-started .` command in 'Our Application' tutorial with original docker file. It was because the `yarn install --production` command depended on python2.
After I added python2 instead of python3 into the docker file, I could successfully build the docker image.

