### PR TITLE
Fix #76

### DIFF
--- a/docs/tutorial/using-bind-mounts/index.md
+++ b/docs/tutorial/using-bind-mounts/index.md
@@ -36,7 +36,13 @@ So, let's do it!
 
 1. Make sure you don't have any previous `getting-started` containers running.
 
-1. Run the following command from the source code folder. We'll explain what's going on afterwards:
+1. Also make sure you are in app source code directory, i.e. `/path/to/getting-started/app`. If you aren't, you can `cd` into it, .e.g:
+
+    ```bash
+    cd /path/to/getting-started/app
+    ```
+
+1. Now that you are in the `getting-started/app` directory, run the following command. We'll explain what's going on afterwards:
 
     ```bash
     docker run -dp 3000:3000 \
@@ -56,7 +62,7 @@ So, let's do it!
 
     - `-dp 3000:3000` - same as before. Run in detached (background) mode and create a port mapping
     - `-w /app` - sets the container's present working directory where the command will run from
-    - `-v "$(pwd):/app"` - bind mount (link) the host's present working directory to the container's `/app` directory
+    - `-v "$(pwd):/app"` - bind mount (link) the host's present `getting-started/app` directory to the container's `/app` directory. Note: Docker requires absolute paths for binding mounts, so in this example we use `pwd` for printing the absolute path of the working directory, i.e. the `app` directory, instead of typing it manually
     - `node:12-alpine` - the image to use. Note that this is the base image for our app from the Dockerfile
     - `sh -c "yarn install && yarn run dev"` - the command. We're starting a shell using `sh` (alpine doesn't have `bash`) and
       running `yarn install` to install _all_ dependencies and then running `yarn run dev`. If we look in the `package.json`,


### PR DESCRIPTION
If the user runs that command "from the source code folder", i.e.
`getting-started`, docker will bind-mount getting-started to the
container's `/app`, which leads to error
`error Couldn't find a package.json file in "/app"`. It needs to bind
`getting-started/app` instead.
So, be explicit to the reader to be on the app source's directory
`getting-started/app` before running the command.

alternative to https://github.com/docker/getting-started/pull/241