### PR TITLE
doc(multi-container-apps): changing headline for arm m1 macbook

### DIFF
--- a/docs/tutorial/multi-container-apps/index.md
+++ b/docs/tutorial/multi-container-apps/index.md
@@ -206,7 +206,7 @@ With all of that explained, let's start our dev-ready container!
       sh -c "yarn install && yarn run dev"
     ```
 
-    If you updated your docker file in the Bind Mount section of the tutorial use the updated command:
+    If you are using an Apple Silicon Mac or another ARM64 device then use this command.
 
     ```bash hl_lines="3 4 5 6 7"
     docker run -dp 3000:3000 \

--- a/docs/tutorial/multi-container-apps/index.md
+++ b/docs/tutorial/multi-container-apps/index.md
@@ -206,6 +206,20 @@ With all of that explained, let's start our dev-ready container!
       sh -c "yarn install && yarn run dev"
     ```
 
+    If you are using PowerShell then use this command.
+
+    ```powershell hl_lines="3 4 5 6 7"
+    docker run -dp 3000:3000 `
+      -w /app -v "$(pwd):/app" `
+      --network todo-app `
+      -e MYSQL_HOST=mysql `
+      -e MYSQL_USER=root `
+      -e MYSQL_PASSWORD=secret `
+      -e MYSQL_DB=todos `
+      node:12-alpine `
+      sh -c "yarn install && yarn run dev"
+    ```
+
     If you are using an Apple Silicon Mac or another ARM64 device then use this command.
 
     ```bash hl_lines="3 4 5 6 7"
@@ -220,19 +234,6 @@ With all of that explained, let's start our dev-ready container!
       sh -c "apk --no-cache --virtual build-dependencies add python2 make g++ && yarn install && yarn run dev"
     ```
 
-    If you are using PowerShell then use this command.
-
-    ```powershell hl_lines="3 4 5 6 7"
-    docker run -dp 3000:3000 `
-      -w /app -v "$(pwd):/app" `
-      --network todo-app `
-      -e MYSQL_HOST=mysql `
-      -e MYSQL_USER=root `
-      -e MYSQL_PASSWORD=secret `
-      -e MYSQL_DB=todos `
-      node:12-alpine `
-      sh -c "yarn install && yarn run dev"
-    ```
 
 1. If we look at the logs for the container (`docker logs <container-id>`), we should see a message indicating it's
    using the mysql database.


### PR DESCRIPTION
### Changes

1)  bbfe32d heading

this command is more for the m1 macbook 
and there is no changing of the docker file in the previous section

2) 9821175 order of command snippets

in previoues sections there was the order:
- normal mac
- powershell
- m1 mac

