### PR TITLE
Fix dead links

### DIFF
--- a/docs/tutorial/index.md
+++ b/docs/tutorial/index.md
@@ -32,9 +32,8 @@ you a quick view of the containers running on your machine. It gives you quick
 access to container logs, lets you get a shell inside the container, and lets you
 easily manage container lifecycle (stop, remove, etc.). 
 
-To access the dashboard, follow the instructions for either 
-[Mac](https://docs.docker.com/docker-for-mac/dashboard/) or 
-[Windows](https://docs.docker.com/docker-for-windows/dashboard/). If you open the dashboard
+To access the dashboard, follow the instructions in the 
+[Docker Desktop manual](https://docs.docker.com/desktop/). If you open the dashboard
 now, you will see this tutorial running! The container name (`jolly_bouman` below) is a
 randomly created name. So, you'll most likely have a different name.
 


### PR DESCRIPTION
Fixed dead links that resulted in 404 errors.
 - https://docs.docker.com/docker-for-mac/dashboard/
 - https://docs.docker.com/docker-for-windows/dashboard/

Updated to a single link to https://docs.docker.com/desktop/

Fixes https://github.com/docker/docker.github.io/issues/15387