### PR TITLE
Change jenkins file to use main over master

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,7 @@ pipeline {
     stages {
         stage('build and push') {
             when {
-                branch 'master'
+                branch 'main'
             }
             sh "docker build -t docker/getting-started ."
 


### PR DESCRIPTION
I noticed the [compose-cli](https://github.com/docker/compose-cli) is using `main` as its default branch. I did a quick project search for instances of 'master' in this repo and only found the `Jenkinsfile` referencing `master`. 

This PR obviously won't work as is and would require someone with permissions to this upstream repo to create a `main` branch, then to change the default branch in GitHub to main. 

Steps to change repo's default branch:
Settings -> Branches -> Default branch -> Switch to another branch

No worries if you don't want to change or if it's not a priority and feel free to close the PR.