### PR TITLE
Update MySQL handler to add timeout for DNS query failures

### DIFF
--- a/app/src/persistence/mysql.js
+++ b/app/src/persistence/mysql.js
@@ -21,7 +21,12 @@ async function init() {
     const password = PASSWORD_FILE ? fs.readFileSync(PASSWORD_FILE) : PASSWORD;
     const database = DB_FILE ? fs.readFileSync(DB_FILE) : DB;
 
-    await waitPort({ host, port : 3306});
+    await waitPort({ 
+        host, 
+        port: 3306,
+        timeout: 10000,
+        waitForDns: true,
+    });
 
     pool = mysql.createPool({
         connectionLimit: 5,


### PR DESCRIPTION
I was helping troubleshoot an issue with someone, who ended up having a typo in their compose file where the MySQL service was using the name "msyql", which obviously causes DNS to fail. But, since the db init doesn't time out, it just looks hung. This fixes that.