### PR TITLE
Add platform flags to Dockerfile to speed up builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
     - name: Build
-      uses: docker/build-push-action@v1
+      uses: docker/build-push-action@v3
       with:
         push: false

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
 # Install the base requirements for the app.
 # This stage is to support development.
-FROM python:alpine AS base
+FROM --platform=$BUILDPLATFORM python:alpine AS base
 WORKDIR /app
 COPY requirements.txt .
 RUN pip install -r requirements.txt
 
-FROM node:18-alpine AS app-base
+FROM --platform=$BUILDPLATFORM node:18-alpine AS app-base
 WORKDIR /app
 COPY app/package.json app/yarn.lock ./
 COPY app/spec ./spec
@@ -25,16 +25,16 @@ RUN apk add zip && \
     zip -r /app.zip /app
 
 # Dev-ready container - actual files will be mounted in
-FROM base AS dev
+FROM --platform=$BUILDPLATFORM base AS dev
 CMD ["mkdocs", "serve", "-a", "0.0.0.0:8000"]
 
 # Do the actual build of the mkdocs site
-FROM base AS build
+FROM --platform=$BUILDPLATFORM base AS build
 COPY . .
 RUN mkdocs build
 
 # Extract the static content from the build
 # and use a nginx image to serve the content
-FROM nginx:alpine
+FROM --platform=$TARGETPLATFORM nginx:alpine
 COPY --from=app-zip-creator /app.zip /usr/share/nginx/html/assets/app.zip
 COPY --from=build /app/site /usr/share/nginx/html


### PR DESCRIPTION
Since the initial mkdocs build and app ZIP creation is platform-independent, I added the `--platform=$BUILDPLATFORM` to reuse the outputs from those stages. Only the final nginx stage uses the `--platform=$TARGETPLATFORM`.