### PR TITLE
Docs: enhance Docker run instructions with port mapping note

### DIFF
--- a/docs/tutorial/our-application/index.md
+++ b/docs/tutorial/our-application/index.md
@@ -78,7 +78,15 @@ command (remember that from earlier?).
     ```bash
     docker run -dp 3000:3000 getting-started
     ```
+    > 💡 **Note:**  
+    > If port `3000` is already in use on your system, you can map the container to a different host port.
 
+    For example:
+
+    ```bash
+    docker run -dp 3001:3000 getting-started
+    ```
+    
     Remember the `-d` and `-p` flags? We're running the new container in "detached" mode (in the 
     background) and creating a mapping between the host's port 3000 to the container's port 3000.
     Without the port mapping, we wouldn't be able to access the application.


### PR DESCRIPTION
This PR improves the Docker run section by clarifying how to map a different
host port when port 3000 is already in use.

This is a documentation-only change aimed at improving clarity for beginners.
