### PR TITLE
docs: fix broken link to Docker security blog on env vars

### DIFF
--- a/docs/tutorial/multi-container-apps/index.md
+++ b/docs/tutorial/multi-container-apps/index.md
@@ -166,7 +166,7 @@ The todo app supports the setting of a few environment variables to specify MySQ
 !!! warning Setting Connection Settings via Env Vars
     While using env vars to set connection settings is generally ok for development, it is **HIGHLY DISCOURAGED**
     when running applications in production. Diogo Monica, a former lead of security at Docker,
-    [wrote a fantastic blog post](https://diogomonica.com/2017/03/27/why-you-shouldnt-use-env-variables-for-secret-data/)
+    [wrote a fantastic blog post](https://blog.diogomonica.com/2017/03/27/why-you-shouldnt-use-env-variables-for-secret-data/)
     explaining why.
 
     A more secure mechanism is to use the secret support provided by your container orchestration framework. In most cases,


### PR DESCRIPTION
The previous link referenced an invalid article. This update points to
Diogo Monica’s blog post explaining why environment variables should not
be used for managing secrets in production.